### PR TITLE
Fix missing NSCameraUsageDescription for iOS

### DIFF
--- a/ios/myviroapp/Info.plist
+++ b/ios/myviroapp/Info.plist
@@ -39,6 +39,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/ios/myviroapp/Info.plist
+++ b/ios/myviroapp/Info.plist
@@ -40,7 +40,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSCameraUsageDescription</key>
-	<string></string>
+	<string>The camera is needed for AR functionality</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
After building and running the app on a iOS device it crashes immediately without that string