### PR TITLE
metro: allow .vrx, .obj, .mtl and other file extension (closes #5)

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -5,13 +5,24 @@
  * @format
  */
 
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: false,
-      },
-    }),
-  },
-};
+const { getDefaultConfig } = require("metro-config");
+
+module.exports = (async () => {
+  const {
+    resolver: { assetExts }
+  } = await getDefaultConfig();
+
+  return {
+    transformer: {
+      getTransformOptions: async () => ({
+        transform: {
+          experimentalImportSupport: false,
+          inlineRequires: false,
+        },
+      }),
+    },
+    resolver: {
+      assetExts: [...assetExts, "obj", "mtl", "JPG", "vrx", "hdr", "gltf", "glb", "bin", "arobject", "gif"]
+    }
+  }
+})();


### PR DESCRIPTION
I found this somewhere on the internet and it works and seems to be the correct solution.